### PR TITLE
Refactor API service to manage our own async dispatch queue

### DIFF
--- a/provide/provide.xcodeproj/project.pbxproj
+++ b/provide/provide.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		68B978D61B085A6C00863E21 /* RenderComponentSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68B978CC1B085A6C00863E21 /* RenderComponentSegue.swift */; };
 		68BA45651FA13FED00322B7C /* ReachabilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BA45641FA13FED00322B7C /* ReachabilityService.swift */; };
 		68C0E6511D56D09800157123 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 68C0E6501D56D09800157123 /* MobileCoreServices.framework */; };
+		68C16A111FAB021E001DAF90 /* ApiOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C16A101FAB021E001DAF90 /* ApiOperation.swift */; };
 		68CD56051F6C8C3B007E66CE /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68CD56041F6C8C3B007E66CE /* PaymentMethod.swift */; };
 		68D843C11BFAA73800DE7400 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D843C01BFAA73800DE7400 /* NotificationService.swift */; };
 		68DCAE461BEC6BB3009B383E /* WorkOrderHistoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68DCAE451BEC6BB3009B383E /* WorkOrderHistoryViewController.swift */; };
@@ -356,6 +357,7 @@
 		68B978CC1B085A6C00863E21 /* RenderComponentSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RenderComponentSegue.swift; sourceTree = "<group>"; };
 		68BA45641FA13FED00322B7C /* ReachabilityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityService.swift; sourceTree = "<group>"; };
 		68C0E6501D56D09800157123 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		68C16A101FAB021E001DAF90 /* ApiOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiOperation.swift; sourceTree = "<group>"; };
 		68CD56041F6C8C3B007E66CE /* PaymentMethod.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentMethod.swift; sourceTree = "<group>"; };
 		68D843C01BFAA73800DE7400 /* NotificationService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		68DCAE451BEC6BB3009B383E /* WorkOrderHistoryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkOrderHistoryViewController.swift; sourceTree = "<group>"; };
@@ -580,6 +582,7 @@
 			isa = PBXGroup;
 			children = (
 				686A5A1B1B0DF96400E0204A /* AnalyticsService.swift */,
+				68C16A101FAB021E001DAF90 /* ApiOperation.swift */,
 				689B0CB11B07DFE3005694B7 /* ApiService.swift */,
 				68B84F191FA8F8A2004264CD /* CategoryService.swift */,
 				6846D99A1F3ED90B004532BD /* CheckinService.swift */,
@@ -1509,6 +1512,7 @@
 				681416F31B8457870076BFBD /* RouteLeg.swift in Sources */,
 				682BE8BE1B43E11A00DDBC3D /* ZeroStateViewController.swift in Sources */,
 				687B650E1C2431800088E539 /* MenuItem.swift in Sources */,
+				68C16A111FAB021E001DAF90 /* ApiOperation.swift in Sources */,
 				6837AF951C8BBD9B0082F4EC /* UserToken.swift in Sources */,
 				5C41C5931B21457800FA7783 /* MessageService.swift in Sources */,
 				68B978C61B084E0E00863E21 /* RoundedButton.swift in Sources */,

--- a/provide/provide/helpers/JSONResponseWriter.swift
+++ b/provide/provide/helpers/JSONResponseWriter.swift
@@ -9,11 +9,9 @@
 import Foundation
 
 class JSONResponseWriter {
-    static func writeResponseToFile(_ operation: RKObjectRequestOperation) {
+    static func writeResponseToFile(_ responseString: String, for request: URLRequest) {
         guard let jsonBaseDir = ProcessInfo.processInfo.environment["WRITE_JSON_RESPONSES"], isSimulator() else { return }
-        guard let responseString = operation.httpRequestOperation.responseString else { return }
 
-        let request = operation.httpRequestOperation.request!
         let outputFilePath = pathForFile(withRequest: request, baseDir: jsonBaseDir)
         writeString(responseString, toFile: outputFilePath)
     }

--- a/provide/provide/models/Model.swift
+++ b/provide/provide/models/Model.swift
@@ -48,10 +48,13 @@ class Model: NSObject {
         super.init()
     }
 
-    required init(string: String) {
+    required init(json: String) {
         super.init()
+        fromJSON(json)
+    }
 
-        let data = string.data(using: .utf8)!
+    func fromJSON(_ json: String) {
+        let data = json.data(using: .utf8)!
         let dictionary = decodeJSON(data)
 
         for (key, var value) in dictionary {
@@ -64,7 +67,7 @@ class Model: NSObject {
 
             if value is NSDictionary {
                 if let clazz = clazz {
-                    value = clazz.init(string: ((value as! NSDictionary) as Dictionary).toJSONString())
+                    value = clazz.init(json: ((value as! NSDictionary) as Dictionary).toJSONString())
                 } else {
                     value = value as! NSDictionary
                 }
@@ -72,7 +75,7 @@ class Model: NSObject {
                 if let clazz = clazz {
                     var newValue = [Model]()
                     for v in value as! NSArray {
-                        newValue.append(clazz.init(string: ((v as! NSDictionary) as Dictionary).toJSONString()))
+                        newValue.append(clazz.init(json: ((v as! NSDictionary) as Dictionary).toJSONString()))
                     }
                     value = newValue
                 } else {

--- a/provide/provide/services/ApiOperation.swift
+++ b/provide/provide/services/ApiOperation.swift
@@ -1,0 +1,253 @@
+//
+//  ApiOperation.swift
+//  provide
+//
+//  Created by Kyle Thomas on 11/2/17.
+//  Copyright © 2017 Provide Technologies Inc. All rights reserved.
+//
+
+import Foundation
+
+class ApiOperation: Operation {
+
+    private let initialBackoffTimeout: TimeInterval = 0.1
+    private let maximumBackoffTimeout: TimeInterval = 60.0
+
+    private var backoffTimeout: TimeInterval!
+
+    private var httpMethod: String {
+        return request.httpMethod!
+    }
+
+    private var idempotent: Bool {
+        return ["GET", "HEAD", "PATCH", "PUT"].contains(httpMethod)
+    }
+
+    private var params: [String: Any]? {
+        if ["PATCH", "POST", "PUT"].contains(httpMethod) {
+            if let body = request.httpBody {
+                let params = try? JSONSerialization.jsonObject(with: body, options: [])
+                if let params = params as? [String: Any] {
+                    return params
+                }
+            }
+        }
+        return nil
+    }
+
+    private var onError: OnError!
+
+    private var onSuccess: OnSuccess!
+
+    private var request: URLRequest!
+
+    private var response: HTTPURLResponse? {
+        return task.response as? HTTPURLResponse
+    }
+
+    private var responseDescriptor: RKResponseDescriptor?
+
+    var responseHeaders: [AnyHashable: Any]? {
+        return response?.allHeaderFields
+    }
+
+    private var responseEntity: Data?
+
+    private var responseString: String? {
+        if let responseEntity = responseEntity {
+            return String(data: responseEntity, encoding: .utf8)
+        }
+        return nil
+    }
+
+    private var url: URL!
+
+    private var statusCode: Int {
+        if let response = response {
+            return response.statusCode
+        }
+        return -1
+    }
+
+    private var task: URLSessionDataTask!
+
+    private weak var session: URLSession!
+
+    override var isAsynchronous: Bool {
+        return true
+    }
+
+    private var _executing = false
+    override var isExecuting: Bool {
+        return _executing
+    }
+
+    private var _finished = false
+    override var isFinished: Bool {
+        return _finished
+    }
+
+    private var _ready = true
+    override var isReady: Bool {
+        return _ready
+    }
+
+    override var description: String {
+        return "\(name!): \(url!)"
+    }
+
+    convenience init(session: URLSession, request: URLRequest, responseDescriptor: RKResponseDescriptor?, onSuccess: OnSuccess!, onError: OnError!) {
+        self.init()
+
+        self.session = session
+        self.request = request
+        self.responseDescriptor = responseDescriptor
+        self.url = self.request.url
+        self.onSuccess = onSuccess
+        self.onError = onError
+
+        var mutableSelf = self
+        withUnsafePointer(to: &mutableSelf) {
+            mutableSelf.name = "ApiOperation[\($0)]"
+        }
+    }
+
+    override func start() {
+        super.start()
+
+        if !isExecuting {
+            _ready = false
+            _executing = true
+            _finished = false
+        }
+
+        logInfo("Dispatching queued API operation \(self)")
+
+        let startDate = Date()
+        task = session.dataTask(with: request) { [weak self] data, response, error in
+            let execTimeMillis: Double = (NSDate().timeIntervalSince(startDate) * 1000.0)
+            let statusCode = self?.statusCode ?? -1
+            self?.responseEntity = data
+
+            if statusCode < 400 && error == nil {
+                self?.onOperationSucceeded(execTimeMillis: execTimeMillis)
+            } else {
+                self?.onOperationFailed(execTimeMillis: execTimeMillis, error: error)
+            }
+
+            self?.finish()
+        }
+
+        task.resume()
+    }
+
+    private func finish() {
+        if isExecuting {
+            _executing = false
+            _finished = true
+
+            logInfo("API operation finished executing: \(self)")
+        }
+    }
+
+    override func cancel() {
+        super.cancel()
+        self.finish()
+
+        AnalyticsService.shared.track("API Operation Canceled", properties: [
+            "operation": self,
+            "path": url.path,
+            "query": url.query ?? "",
+            "statusCode": statusCode,
+            "params": params as Any,
+            "backoffTimeout": backoffTimeout,
+        ])
+    }
+
+    private func onOperationSucceeded(execTimeMillis: Double) {
+        let statusCode = self.statusCode
+        let contentLength = Int64(responseEntity?.count ?? 0)
+
+        logmoji("✅", "\(statusCode): \(request.url!) (\(contentLength)-byte response); took \(execTimeMillis)ms")
+
+        AnalyticsService.shared.track("API Operation Succeeded", properties: [
+            "operation": self,
+            "path": url.path,
+            "query": url.query ?? "",
+            "statusCode": statusCode,
+            "contentLength": contentLength,
+            "params": params as Any,
+            "execTimeMillis": execTimeMillis,
+        ])
+
+        if let mappingOperation = RKObjectResponseMapperOperation(request: request, response: response, data: responseEntity, responseDescriptors: [responseDescriptor as Any]) {
+            mappingOperation.setDidFinishMappingBlock { [weak self] mappingResult, error in
+                if let strongSelf = self {
+                    if ProcessInfo.processInfo.environment["WRITE_JSON_RESPONSES"] != nil {
+                        JSONResponseWriter.writeResponseToFile(strongSelf.responseString!, for: strongSelf.request!)
+                    }
+
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onSuccess?(statusCode, mappingResult)
+                    }
+                }
+            }
+            mappingOperation.start()
+        }
+    }
+
+    private func onOperationFailed(execTimeMillis: Double, error: Error?) {
+        let receivedResponse = responseEntity != nil
+        let contentLength = Int64(responseEntity?.count ?? 0)
+
+        if receivedResponse {
+            self.backoffTimeout = self.initialBackoffTimeout
+
+            AnalyticsService.shared.track("API Operation Failed", properties: [
+                "operation": self,
+                "path": url.path,
+                "query": url.query ?? "",
+                "statusCode": statusCode,
+                "contentLength": contentLength,
+                "params": params as Any,
+                "execTimeMillis": execTimeMillis,
+            ])
+
+            if statusCode == 401 {
+                if request.url?.baseURL?.absoluteString == CurrentEnvironment.baseUrlString {
+                    KTNotificationCenter.post(name: .ApplicationShouldForceLogout)
+                }
+            }
+        } else if let err = error as NSError? {
+            logError(err)
+            AnalyticsService.shared.track("API Operation Failed", properties: [
+                "operation": self,
+                "path": url.path,
+                "query": url.query ?? "",
+                "error": err.localizedDescription,
+                "code": err.code,
+                "params": params as Any,
+                "execTimeMillis": execTimeMillis,
+            ])
+
+            let deadline = DispatchTime.now() + Double(Int64(self.backoffTimeout * Double(NSEC_PER_SEC)))
+            self.backoffTimeout = self.backoffTimeout > 60.0 ? self.initialBackoffTimeout : self.backoffTimeout * 2
+            DispatchQueue.global(qos: DispatchQoS.default.qosClass).asyncAfter(deadline: deadline) { [weak self] in
+                self?.responseEntity = nil
+                self?.task?.resume()
+            }
+
+            DispatchQueue.main.async { [weak self] in
+                if let strongSelf = self {
+                    strongSelf.onError?(err, strongSelf.statusCode, strongSelf.responseString ?? "{}")
+                }
+            }
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                if let strongSelf = self {
+                    strongSelf.onError?(NSError(), strongSelf.statusCode, strongSelf.responseString ?? "{}")
+                }
+            }
+        }
+    }
+}

--- a/provide/provide/services/KeyChainService.swift
+++ b/provide/provide/services/KeyChainService.swift
@@ -60,7 +60,7 @@ class KeyChainService {
             if let token = cachedToken {
                 return token
             } else if let tokenJsonString = self["token"] {
-                cachedToken = Token(string: tokenJsonString)
+                cachedToken = Token(json: tokenJsonString)
                 return cachedToken
             } else {
                 return nil

--- a/provide/provide/services/NSNotification.Name.swift
+++ b/provide/provide/services/NSNotification.Name.swift
@@ -15,6 +15,7 @@ extension NSNotification.Name {
     static let ApplicationUserLoggedOut = NSNotification.Name("ApplicationUserLoggedOut")
     static let ApplicationUserShouldLogout = NSNotification.Name("ApplicationUserShouldLogout")
     static let ApplicationUserWasAuthenticated = NSNotification.Name("ApplicationUserWasAuthenticated")
+    static let ApplicationShouldForceLogout = NSNotification.Name("ApplicationShouldForceLogout")
     static let ApplicationWillRegisterUserNotificationSettings = NSNotification.Name("ApplicationWillRegisterUserNotificationSettings")
     static let ApplicationWillRequestLocationAuthorization = NSNotification.Name("ApplicationWillRequestLocationAuthorization")
     static let ApplicationWillRequestMediaAuthorization = NSNotification.Name("ApplicationWillRequestMediaAuthorization")

--- a/provide/provide/services/NotificationService.swift
+++ b/provide/provide/services/NotificationService.swift
@@ -97,7 +97,7 @@ class NotificationService: NSObject, JFRWebSocketDelegate {
             }
         case .message:
             let jsonString = (notificationValue as! [String: Any]).toJSONString()
-            let message = Message(string: jsonString)
+            let message = Message(json: jsonString)
             KTNotificationCenter.post(name: .NewMessageReceivedNotification, object: message)
 
         case .workOrder:
@@ -196,7 +196,7 @@ class NotificationService: NSObject, JFRWebSocketDelegate {
     static func handleWebsocketMessage(_ messageName: String, payload: [String: Any]) {
         switch messageName {
         case "attachment_changed":
-            let attachment = Attachment(string: payload.toJSONString())
+            let attachment = Attachment(json: payload.toJSONString())
             if let url = payload["url"] as? String {
                 attachment.urlString = url // FIXME-- marshall with proper mapping
             }
@@ -207,7 +207,7 @@ class NotificationService: NSObject, JFRWebSocketDelegate {
             KTNotificationCenter.post(name: .AttachmentChanged, object: attachment)
         case "provider_became_available":
             let providerJson = payload.toJSONString()
-            let provider = Provider(string: providerJson)
+            let provider = Provider(json: providerJson)
             if ProviderService.shared.containsProvider(provider) {
                 ProviderService.shared.updateProvider(provider)
             } else {
@@ -221,7 +221,7 @@ class NotificationService: NSObject, JFRWebSocketDelegate {
             }
         case "provider_location_changed":
             let providerJson = payload.toJSONString()
-            let provider = Provider(string: providerJson)
+            let provider = Provider(json: providerJson)
             if ProviderService.shared.containsProvider(provider) {
                 ProviderService.shared.updateProvider(provider)
             } else {
@@ -230,7 +230,7 @@ class NotificationService: NSObject, JFRWebSocketDelegate {
             KTNotificationCenter.post(name: .ProviderLocationChanged, object: provider)
         case "work_order_changed":
             let workOrderJson = payload.toJSONString()
-            let workOrder = WorkOrder(string: workOrderJson)
+            let workOrder = WorkOrder(json: workOrderJson)
             WorkOrderService.shared.updateWorkOrder(workOrder)
             KTNotificationCenter.post(name: .WorkOrderChanged, object: workOrder)
             if WorkOrderService.shared.inProgressWorkOrder == nil {


### PR DESCRIPTION
This is a pretty big upgrade.

There are still a few gaps that I need to fill in, particularly related to request cancelation.

The only major item that is missing is getting the `RKObjectMapper` mapped using the response string. You mentioned something about Alamofire object mapping IIRC, maybe it would make sense to put that in alongside this PR since this breaks `RKObjectMapper`